### PR TITLE
Darker caret for MaterialMonkaiLight

### DIFF
--- a/MaterialMonokaiLight.tmTheme
+++ b/MaterialMonokaiLight.tmTheme
@@ -12,7 +12,7 @@
               <key>background</key>
               <string>#FAFAFA</string>
               <key>caret</key>
-              <string>#F8F8F0</string>
+              <string>#75715E</string>
               <key>foreground</key>
               <string>#12191C</string>
               <key>invisibles</key>


### PR DESCRIPTION
Current caret color was very difficult to see on views that don't implement current line highlighting (ie, GitSavyy dashboard).

This change makes it the same color as comments and works very well on views with and without line highlighting.